### PR TITLE
There should be support for requiring other sections of the norm map

### DIFF
--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -53,7 +53,9 @@
      (ensure-conformity-attribute conn conformity-attr)
      (doseq [norm norm-names]
        (when-not (conforms-to? (db conn) conformity-attr norm)
-         (let [{txes :txes} (get norm-map norm)]
+         (let [{:keys [txes requires]} (get norm-map norm)]
+           (when requires
+             (ensure-conforms conn conformity-attr norm-map requires))
            (if txes
              (doseq [tx txes]
                ;; hrm, could mark the last tx specially
@@ -62,3 +64,4 @@
                                        tx)))
              (throw (ex-info (str "No data provided for norm " norm)
                              {:schema/missing norm}))))))))
+


### PR DESCRIPTION
This adds support to `ensure-conforms` for `:require` vecs that establish schema dependency in the norm map.

This idea was sourced from [day-of-datomic's schema changes](https://github.com/Datomic/day-of-datomic/blob/master/src/datomic/samples/schema.clj#L65)
