### PR TITLE
include failing tx when transacting throws

### DIFF
--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -58,10 +58,13 @@
              (ensure-conforms conn conformity-attr norm-map requires))
            (if txes
              (doseq [tx txes]
-               ;; hrm, could mark the last tx specially
-               @(d/transact conn (cons {:db/id (d/tempid :db.part/tx)
-                                        conformity-attr norm}
-                                       tx)))
+               (try
+                 ;; hrm, could mark the last tx specially
+                 @(d/transact conn (cons {:db/id (d/tempid :db.part/tx)
+                                          conformity-attr norm}
+                                         tx))
+                 (catch Throwable t
+                   (throw (ex-info (.getMessage t) {:tx tx} t)))))
              (throw (ex-info (str "No data provided for norm " norm)
                              {:schema/missing norm}))))))))
 


### PR DESCRIPTION
datomic doesn't tell you what failed at all here (would be nice if it did), but it
seems like we should include this data when transacting fails.
