### PR TITLE
Add arity for `ensure-norms` that only takes `conn` and `norm-map`.

### DIFF
--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -47,7 +47,9 @@
       norm-map         a map from norm names to data maps.
                        the data map contains one keys:
                          :txes     - the data to install
-      norm-names       A collection of names of norms to conform to"
+      norm-names       (optional) A collection of names of norms to conform to.
+                       Will use keys of norm-map if not provided."
+  ([conn norm-map] (ensure-conforms conn norm-map (keys norm-map)))
   ([conn norm-map norm-names] (ensure-conforms conn default-conformity-attribute norm-map norm-names))
   ([conn conformity-attr norm-map norm-names]
      (ensure-conformity-attribute conn conformity-attr)

--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -27,28 +27,51 @@
                                  :db/index false
                                  :db.install/_attribute :db.part/db}]]}})
 
+(def sample-norms-map2 {:test2/norm-1
+                        {:txes [[{:db/id #db/id [:db.part/db]
+                                  :db/ident :test/attribute
+                                  :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one
+                                  :db/fulltext false
+                                  :db/index false
+                                  :db.install/_attribute :db.part/db}]]}
+                        :test2/norm-2
+                        {:txes [[{:db/id #db/id [:db.part/db]
+                                  :db/ident :test/attribute2
+                                  :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one
+                                  :db/fulltext false
+                                  :db/index false
+                                  :db.install/_attribute :db.part/db}]]}})
+
 (deftest test-ensure-conforms
-  (testing "installs all norm expected"
+  (testing "installs all norm expected with explicit norms list"
     (let [conn (fresh-conn)]
       (ensure-conforms conn sample-norms-map [:test/norm-1])
       (is (= 1 (count (q '[:find ?e :where [?e :db/ident :test/attribute]] (db conn)))))))
-  
+
+  (testing "installs all norm expected with no explicit norms list"
+    (let [conn (fresh-conn)]
+      (ensure-conforms conn sample-norms-map2)
+      (is (= 1 (count (q '[:find ?e :where [?e :db/ident :test/attribute]] (db conn)))))
+      (is (= 1 (count (q '[:find ?e :where [?e :db/ident :test/attribute2]] (db conn)))))))
+
   (testing "throws exception if norm-map lacks transactions for a norm"
     (let [conn (fresh-conn)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No data provided for norm :test/norm-2"
-            (ensure-conforms conn {:test/norm-2 {}} [:test/norm-2]))))))
+                            (ensure-conforms conn {:test/norm-2 {}} [:test/norm-2]))))))
 
 (deftest test-conforms-to?
   (testing "returns true if a norm is already installed"
     (let [conn (fresh-conn)]
       (ensure-conforms conn sample-norms-map [:test/norm-1])
       (is (= true (conforms-to? (db conn) :test/norm-1)))))
-  
+
   (testing "returns false if a norm has not been installed"
     (let [conn (fresh-conn)]
       (ensure-conformity-attribute conn default-conformity-attribute)
       (is (= false (conforms-to? (db conn) :test/norm-1)))))
-  
+
   (testing "returns false if conformity-attr does not exist"
     (let [conn (fresh-conn)]
       (is (= false (conforms-to? (db conn) :test/norm-1))))))
@@ -57,7 +80,7 @@
   (testing "it adds the conformity attribute if it is absent"
     (let [conn (fresh-conn)]
       (ensure-conformity-attribute conn :test/conformity)
-      (is (= true (has-attribute? (db conn) :test/conformity))))) 
+      (is (= true (has-attribute? (db conn) :test/conformity)))))
 
   (testing "it does nothing if the conformity attribute exists"
     (defn count-txes [conn] (count (q '[:find ?tx :where [?tx :db/txInstant _]] (db conn))))


### PR DESCRIPTION
`norm-names` is inferred from `(keys norm-map)`.
