### PR TITLE
Transactional update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # conformity
 
-A Clojure/Datomic library for idempotently\* transacting datoms (norms) into your database – be they schema, data, or otherwise.
+A Clojure/Datomic library for idempotently transacting datoms (norms) into your database – be they schema, data, or otherwise.
 
-In the simplest sense, conformity allows you to write schema migrations and ensure that they run once and only  once.
+In the simplest sense, conformity allows you to write schema migrations and ensure that they run once and only once.
 
 In a more general sense, conformity allows you to declare expectations (in the form of norms) about the state of your database, and enforce those idempotently without repeatedly transacting schema, required data, etc.
-
-
->\* I say idempotent in the sense that running `ensure-conforms` repeatedly in serial will not transact your norms more than once. If you do so in parallel I make no guarantees about behavior.
 
 ## Dependency
 

--- a/README.md
+++ b/README.md
@@ -79,20 +79,6 @@ Once a norm is conformed to that's it! *It won't be transacted again*. That does
 
 In the future you may be able to intelligently version norms themselves, but I had to draw the line somewhere for the initial release.
 
-## But I use datomic-pro!
-
-Awesome, I love you!
-
-Unfortunately there isn't an easy way to rely on either pro or free, so I decided to choose datomic-free for the least friction.
-
-If you're using the pro version of Datomic you'll need to exclude the datomic-free dependency introduced by depending on conformity like so:
-
-```clojure
-; project.clj, inside your :dependencies map…
-
-[io.rkn/conformity "0.3.3" :exclusions [com.datomic/datomic-free]]
-```
-
 ## License
 
 Copyright © 2012-2014 Ryan Neufeld

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Then in your code:
 # src/my_project/something.clj
 ```clojure
 (ns my-project.something
-  (:use [io.rkn.conformity :as c]
-        [datomic.api :as d]))
+  (:require [io.rkn.conformity :as c]
+            [datomic.api :as d]))
 
 (def uri "datomic:mem://my-project")
 (d/create-database uri)
@@ -56,13 +56,13 @@ You can see this more directly illustrated in a console…
 ; nREPL 0.1.5
 
 ; Setup a in-memory db
-(use '[datomic.api :as d])
+(require '[datomic.api :as d])
 (def uri "datomic:mem://my-project")
 (d/create-database uri)
 (def conn (d/connect uri))
 
 ; Hook up conformity and your sample datom
-(use '[io.rkn.conformity :as c])
+(require '[io.rkn.conformity :as c])
 (defn load-resource [filename] (read-string (slurp (clojure.java.io/reader (clojure.java.io/resource filename)))))
 (def norms-map (load-resource "something.edn"))
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject io.rkn/conformity "0.3.5-SNAPSHOT"
-  :description "(Mostly) idempotent datom transacting for Datomic.\n\nSpecial thanks to Stuart Halloway for the original idea, implementation and permission to take it and run."
+  :description "Idempotent datom transacting for Datomic.\n\nSpecial thanks to Stuart Halloway for the original idea, implementation and permission to take it and run."
   :url "http://github.com/rkneufeld/conformity"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/rkneufeld/conformity"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.datomic/datomic-free "0.9.4815.12"]]
-  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.3"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
+                                  [com.datomic/datomic-free "0.9.4815.12"]
+                                  [org.clojure/tools.namespace "0.2.3"]]
                    :source-paths ["dev"]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.rkn/conformity "0.3.4"
+(defproject io.rkn/conformity "0.3.5-SNAPSHOT"
   :description "(Mostly) idempotent datom transacting for Datomic.\n\nSpecial thanks to Stuart Halloway for the original idea, implementation and permission to take it and run."
   :url "http://github.com/rkneufeld/conformity"
   :license {:name "Eclipse Public License"

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -31,11 +31,12 @@
            (str (name conformity-attr) "-index")))
 
 (defn has-attribute?
-    "Check if a database has an attribute named attr-name"
-    [db attr-name]
-    (-> (d/entity db attr-name)
-        :db.install/_attribute
-        boolean))
+  "Returns true if a database has an attribute named attr-name"
+  [db attr-name]
+  (-> (d/entity db attr-name)
+      :db.install/_attribute
+      boolean))
+
 (defn has-function?
   "Returns true if a database has a function named fn-name"
   [db fn-name]
@@ -102,8 +103,10 @@
                                      in norm-map.
       norm-names       (optional) A collection of names of norms to conform to.
                        Will use keys of norm-map if not provided."
-  ([conn norm-map] (ensure-conforms conn norm-map (keys norm-map)))
-  ([conn norm-map norm-names] (ensure-conforms conn default-conformity-attribute norm-map norm-names))
+  ([conn norm-map]
+   (ensure-conforms conn norm-map (keys norm-map)))
+  ([conn norm-map norm-names]
+   (ensure-conforms conn default-conformity-attribute norm-map norm-names))
   ([conn conformity-attr norm-map norm-names]
      (doseq [norm norm-names]
        (when-not (conforms-to? (db conn) conformity-attr norm)

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -43,9 +43,10 @@
       :db/fn
       boolean))
 
-(defn ensure-conformity-attribute
-  "Ensure that conformity-attr, a keyword-valued attribute,
-   is installed in the database."
+(defn ensure-conformity-schema
+  "Ensure that the two attributes and one transaction function
+  required to track conformity via the conformity-attr keyword
+  parameter are installed in the database."
   [conn conformity-attr]
   (when-not (has-attribute? (db conn) conformity-attr)
     (d/transact conn [{:db/id (d/tempid :db.part/db)
@@ -98,7 +99,6 @@
   ([conn norm-map] (ensure-conforms conn norm-map (keys norm-map)))
   ([conn norm-map norm-names] (ensure-conforms conn default-conformity-attribute norm-map norm-names))
   ([conn conformity-attr norm-map norm-names]
-     (ensure-conformity-attribute conn conformity-attr)
      (doseq [norm norm-names]
        (when-not (conforms-to? (db conn) conformity-attr norm)
          (let [{:keys [txes requires]} (get norm-map norm)]
@@ -116,3 +116,4 @@
              (throw (ex-info (str "No data provided for norm " norm)
                              {:schema/missing norm}))))))))
 
+   (ensure-conformity-schema conn conformity-attr)

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -14,7 +14,10 @@
                                :in $ ?na ?nv ?ia ?iv
                                :where [?tx ?na ?nv ?tx] [?tx ?ia ?iv ?tx]]
                              db norm-attr norm index-attr index))
-             tx)}))
+             (cons {:db/id (d/tempid :db.part/tx)
+                    norm-attr norm
+                    index-attr index}
+                   tx))}))
 
 (defn load-schema-rsc
   "Load an edn schema resource file"
@@ -123,9 +126,6 @@
          @(d/transact conn [[conformity-ensure-norm-tx
                              conformity-attr norm
                              (index-attr conformity-attr) index
-                             (cons {:db/id (d/tempid :db.part/tx)
-                                    conformity-attr norm
-                                    (index-attr conformity-attr) index}
-                                   tx)]])
+                             tx]])
          (catch Throwable t
            (throw (ex-info (.getMessage t) {:tx tx} t))))))))

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -24,6 +24,12 @@
       slurp
       read-string))
 
+(defn index-attr
+  "Returns the index-attr corresponding to a conformity-attr"
+  [conformity-attr]
+  (keyword (namespace conformity-attr)
+           (str (name conformity-attr) "-index")))
+
 (defn has-attribute?
     "Check if a database has an attribute named attr-name"
     [db attr-name]
@@ -47,8 +53,14 @@
                        :db/valueType :db.type/keyword
                        :db/cardinality :db.cardinality/one
                        :db/doc "Name of schema installed by this transaction"
+  (when-not (has-attribute? (db conn) (index-attr conformity-attr))
+    (d/transact conn [{:db/id (d/tempid :db.part/db)
+                       :db/ident (index-attr conformity-attr)
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one
+                       :db/doc "Index of this transaction within its norm"
                        :db/index true
-                       :db.install/_attribute :db.part/db}])))
+                       :db.install/_attribute :db.part/db}]))
   (when-not (has-function? (db conn) conformity-ensure-norm-tx)
     (d/transact conn [{:db/id (d/tempid :db.part/user)
                        :db/ident conformity-ensure-norm-tx

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -1,6 +1,6 @@
 (ns io.rkn.conformity
-  (:use [datomic.api :only [q db] :as d]
-        [clojure.java.io :as io]))
+  (:require [datomic.api :refer [q db] :as d]
+            [clojure.java.io :as io]))
 
 (def default-conformity-attribute :confirmity/conformed-norms)
 

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -53,7 +53,9 @@
                        :db/ident conformity-attr
                        :db/valueType :db.type/keyword
                        :db/cardinality :db.cardinality/one
-                       :db/doc "Name of schema installed by this transaction"
+                       :db/doc "Name of this transaction's norm"
+                       :db/index true
+                       :db.install/_attribute :db.part/db}]))
   (when-not (has-attribute? (db conn) (index-attr conformity-attr))
     (d/transact conn [{:db/id (d/tempid :db.part/db)
                        :db/ident (index-attr conformity-attr)
@@ -71,9 +73,6 @@
 (defn conforms-to?
   "Does database have a norm installed?
 
-      conformity-attr  (optional) the keyword name of the attribute used to track
-                       conformity
-      norm             the keyword name of the norm you want to check"
   ([db norm] (conforms-to? db default-conformity-attribute norm))
   ([db conformity-attr norm]
      (and (has-attribute? db conformity-attr)
@@ -82,17 +81,21 @@
                    :where [?e ?sa ?sn ?e]]
                  db conformity-attr norm)
               seq boolean))))
+      conformity-attr  (optional) the keyword name of the attribute used to
+                       track conformity
+      norm             the keyword name of the norm you want to check
+      tx-count         the count of transactions for that norm"
 
 (defn ensure-conforms
   "Ensure that norms represented as datoms are conformed-to (installed), be they
-   schema, data or otherwise.
+  schema, data or otherwise.
 
-      conformity-attr  (optional) the keyword-valued attribute where conformity
-                       tracks enacted norms.
+      conformity-attr  (optional) the keyword name of the attribute used to
+                       track conformity
       norm-map         a map from norm names to data maps.
-                       the data map contains:
+                       a data map contains:
                          :txes     - the data to install
-                         :requires - (optional) The name of a prerequisite norm
+                         :requires - (optional) a list of prerequisite norms
                                      in norm-map.
       norm-names       (optional) A collection of names of norms to conform to.
                        Will use keys of norm-map if not provided."

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -73,18 +73,21 @@
 (defn conforms-to?
   "Does database have a norm installed?
 
-  ([db norm] (conforms-to? db default-conformity-attribute norm))
-  ([db conformity-attr norm]
-     (and (has-attribute? db conformity-attr)
-          (-> (q '[:find ?e
-                   :in $ ?sa ?sn
-                   :where [?e ?sa ?sn ?e]]
-                 db conformity-attr norm)
-              seq boolean))))
       conformity-attr  (optional) the keyword name of the attribute used to
                        track conformity
       norm             the keyword name of the norm you want to check
       tx-count         the count of transactions for that norm"
+  ([db norm tx-count]
+   (conforms-to? db default-conformity-attribute norm tx-count))
+  ([db conformity-attr norm tx-count]
+   (and (has-attribute? db conformity-attr)
+        (pos? tx-count)
+        (-> (q '[:find ?tx
+                 :in $ ?na ?nv
+                 :where [?tx ?na ?nv ?tx]]
+               db conformity-attr norm)
+            count
+            (= tx-count)))))
 
 (defn ensure-conforms
   "Ensure that norms represented as datoms are conformed-to (installed), be they

--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -9,40 +9,33 @@
   (d/create-database uri)
   (d/connect uri))
 
-(def sample-norms-map {:test/norm-1
-                       {:txes [[{:db/id #db/id [:db.part/db]
-                                 :db/ident :test/attribute
-                                 :db/valueType :db.type/string
-                                 :db/cardinality :db.cardinality/one
-                                 :db/fulltext false
-                                 :db/index false
-                                 :db.install/_attribute :db.part/db}]]}
-                       :test/bad-norm-1
-                       {:txes [[{:db/id #db/id [:db.part/db]
-                                 :db/ident :test/attribute
-                                 ;; Bad data type - should 'splode
-                                 :db/valueType :db.type/nosuch
-                                 :db/cardinality :db.cardinality/one
-                                 :db/fulltext false
-                                 :db/index false
-                                 :db.install/_attribute :db.part/db}]]}})
+(defn attr
+  ([ident]
+   (attr ident :db.type/string))
+  ([ident value-type]
+   [{:db/id (d/tempid :db.part/db)
+     :db/ident ident
+     :db/valueType value-type
+     :db/cardinality :db.cardinality/one
+     :db.install/_attribute :db.part/db}]))
 
-(def sample-norms-map2 {:test2/norm-1
-                        {:txes [[{:db/id #db/id [:db.part/db]
-                                  :db/ident :test/attribute
-                                  :db/valueType :db.type/string
-                                  :db/cardinality :db.cardinality/one
-                                  :db/fulltext false
-                                  :db/index false
-                                  :db.install/_attribute :db.part/db}]]}
-                        :test2/norm-2
-                        {:txes [[{:db/id #db/id [:db.part/db]
-                                  :db/ident :test/attribute2
-                                  :db/valueType :db.type/string
-                                  :db/cardinality :db.cardinality/one
-                                  :db/fulltext false
-                                  :db/index false
-                                  :db.install/_attribute :db.part/db}]]}})
+(def sample-norms-map1 {:test1/norm1
+                        {:txes [(attr :test/attribute1)
+                                (attr :test/attribute2)]}
+                        :test1/norm2
+                        {:txes [(attr :test/attribute3)]}})
+
+(def sample-norms-map2 {:test2/norm1
+                        {:txes [(attr :test/attribute1)]}
+                        :test2/norm2 ;; Bad data type - should 'splode
+                        {:txes [(attr :test/attribute2 :db.type/nosuch)]}})
+
+(def sample-norms-map3 {:test3/norm1
+                        {:txes [(attr :test/attribute1)
+                                (attr :test/attribute2)]}
+                        :test3/norm2
+                        {:txes [(attr :test/attribute3)]
+                         :requires [:test3/norm1]}})
 
 (deftest test-ensure-conforms
   (testing "installs all norm expected with explicit norms list"

--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -1,7 +1,7 @@
 (ns io.rkn.conformity-test
-  (:use clojure.test
-        io.rkn.conformity
-        [datomic.api :only [q db] :as d]))
+  (:require [clojure.test :refer :all]
+            [io.rkn.conformity :refer :all]
+            [datomic.api :refer [q db] :as d]))
 
 (def uri  "datomic:mem://test")
 (defn fresh-conn []


### PR DESCRIPTION
This update makes conforming to norms transactional by using a transaction function to do the required checks.

Transactional norm conformance makes deployment easier when there are multiple clients to be deployed. It removes worries about possible negative effects of multiple clients updating the database with new norms concurrently. With the new code in place, concurrent updates from multiple clients should reliably achieve the desired end state in all cases. This is also the subject of issue #15 which I think can be closed if this pull request is accepted.

Viewing a norm as a seq of transactions, in addition to tracking which norm each transaction comes from, the new code also tracks the numeric index of that transaction within its norm's :txes seq. Each transaction is therefore uniquely identifiable and by using the new transaction function we know that each has either completed in its entirety or has not yet run.

The primary external API "ensure-conforms" and the format of a norm map are unchanged. There was a necessary change to the arguably external "conforms-to?" API to include a count of the transactions associated with a norm name. Note that any existing databases that have completed conforming to existing norms using code before this pull request will still show as conforming to the corresponding norms with the new code--the new check for conformity only requires that the *count* of transactions marked as belonging to the norm is correct, not that each transaction is marked with its transaction seq index as well as its norm name.

Please consider accepting this pull request. I'm happy to discuss and make any required corrections or changes to make it acceptable.