### PR TITLE
read directly from the resource, no intermediate string

### DIFF
--- a/resources/sample4.edn
+++ b/resources/sample4.edn
@@ -1,0 +1,20 @@
+{:test4/norm1
+ {:txes [[{:db/ident :test/attribute1
+           :db/doc "test attribute 1"
+           :db/valueType :db.type/string
+           :db/cardinality :db.cardinality/one
+           :db/id #db/id[:db.part/db]
+           :db.install/_attribute :db.part/db}
+          {:db/ident :test/user
+           :db/doc "test user"
+           :db/valueType :db.type/string
+           :db/cardinality :db.cardinality/one
+           :db/id #db/id[:db.part/db]
+           :db.install/_attribute :db.part/db}
+          {:db/ident :test/transaction-metadata
+           :db/doc "annotates the transaction with metadata"
+           :db/id #db/id[:db.part/user]
+           :db/fn #db/fn
+           {:lang :clojure
+            :params [db metadata]
+            :code [(assoc metadata :db/id #db/id[:db.part/tx])]}}]]}}

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -19,13 +19,16 @@
                     index-attr index}
                    tx))}))
 
-(defn load-schema-rsc
-  "Load an edn schema resource file"
-  [resource-filename]
-  (-> resource-filename
-      io/resource
-      slurp
-      read-string))
+(defn read-resource
+  "Reads and returns data from a resource containing edn text. An
+  optional argument allows specifying opts for clojure.edn/read"
+  ([resource-name]
+   (read-resource {:readers *data-readers*} resource-name))
+  ([opts resource-name]
+   (->> (io/resource resource-name)
+        (io/reader)
+        (java.io.PushbackReader.)
+        (clojure.edn/read opts))))
 
 (defn index-attr
   "Returns the index-attr corresponding to a conformity-attr"


### PR DESCRIPTION
- uses less memory, not requiring the entire resource contents in memory
  before reading
- renamed `load-schema-rsc` to `read-resource` to more clearly indicate what it does
  - there's nothing schema or norm specific about it
- `clojure.edn/read` is safer than `read-string` regarding `read-eval`
- the test provides an example of a more typical `ensure-conforms` use
  - from a resource rather than from Clojure source