### PR TITLE
sync schema before calling transact

### DIFF
--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -37,6 +37,19 @@
                         {:txes [(attr :test/attribute3)]
                          :requires [:test3/norm1]}})
 
+(def sample-norms-map5 {:test4/norm1
+                        {:txes [[{:db/id (d/tempid :db.part/db)
+                                  :db/ident :test/unique-attribute
+                                  :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one
+                                  :db.install/_attribute :db.part/db}]
+                                [{:db/id :test/unique-attribute
+                                  :db/index true
+                                  :db.alter/_attribute :db.part/db}]
+                                [{:db/id :test/unique-attribute
+                                  :db/unique :db.unique/value
+                                  :db.alter/_attribute :db.part/db}]]}})
+
 (deftest test-ensure-conforms
   (testing "installs all expected norms"
 
@@ -49,6 +62,11 @@
         (is (has-attribute? (db conn) :test/attribute2))
         (is (has-attribute? (db conn) :test/attribute3))
         (is (empty? (ensure-conforms conn sample-norms-map1)))))
+
+    (testing "can add db/unique after an avet index add"
+      (let [conn (fresh-conn)
+            result (ensure-conforms conn sample-norms-map5)]
+        (is (has-attribute? (db conn) :test/unique-attribute))))
 
     (testing "with explicit norms list"
       (let [conn (fresh-conn)


### PR DESCRIPTION
This lets you add :db/index as schema alterations without having to
deploy two sets of production changes and manually call synch-schema
between them. For the average user, it won't add any extra time to the
time for migrations.

This also lets the user pass a timeout for sync-schema in the norm map,
via setting :conformity.setting/sync-schema-timeout to a value in
milliseconds. This is passed directly to deref. If the timout is hit,
conformity will throw an exception.

Fixes https://github.com/rkneufeld/conformity/issues/22