### PR TITLE
Ensure correct order for :txes-fn requires

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.rkn/conformity "0.5.0"
+(defproject io.rkn/conformity "0.5.1"
   :description "Idempotent datom transacting for Datomic.\n\nSpecial thanks to Stuart Halloway for the original idea, implementation and permission to take it and run."
   :url "http://github.com/rkneufeld/conformity"
   :license {:name "Eclipse Public License"

--- a/resources/migrations/requiring.clj
+++ b/resources/migrations/requiring.clj
@@ -1,0 +1,24 @@
+(ns migrations.requiring
+  (:require [datomic.api :as d]))
+
+(def attr-q
+  '[:find ?e
+    :in $ ?attr ?v
+    :where
+    [?e ?attr ?v]])
+
+(defn find-eids-with-val-for-attr
+  [db attr val]
+  (map first
+       (d/q attr-q db attr val)))
+
+(defn txes
+  "Everybody who liked green now likes orange instead."
+  [conn]
+  (let [green-eids (find-eids-with-val-for-attr
+                    (d/db conn)
+                    :preferences/color
+                    "green")]
+    [(for [eid green-eids]
+       [:db/add eid
+        :preferences/color "orange"])]))

--- a/resources/requiring-sample.edn
+++ b/resources/requiring-sample.edn
@@ -1,0 +1,14 @@
+{:requiring/base
+ {:txes [[{:db/ident :preferences/color
+           :db/valueType :db.type/string
+           :db/cardinality :db.cardinality/one
+           :db/id #db/id[:db.part/db]
+           :db.install/_attribute :db.part/db}]
+
+         [{:db/id #db/id[:db.part/user]
+           :preferences/color "green"}]]}
+
+:requiring/dependent
+ {:requires [:requiring/base]
+  :txes-fn migrations.requiring/txes}}
+

--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -164,25 +164,25 @@
   [acc conn norm-attr norm-map norm-names]
   (let [sync-schema-timeout (:conformity.setting/sync-schema-timeout norm-map)]
     (reduce
-      (fn [acc norm-name]
-        (let [{:keys [txes requires ex]} (get-norm conn norm-map norm-name)]
-          (cond (conforms-to? (db conn) norm-attr norm-name (count txes))
-                acc
+     (fn [acc norm-name]
+       (let [{:keys [txes requires ex]} (get-norm conn norm-map norm-name)]
+         (cond (conforms-to? (db conn) norm-attr norm-name (count txes))
+               acc
 
-                (empty? txes)
-                (let [reason (or ex
-                                 (str "No transactions provided for norm "
-                                      norm-name))
-                      data {:succeeded acc
-                            :failed {:norm-name norm-name
-                                     :reason reason}}]
-                  (throw (ex-info reason data)))
+               (empty? txes)
+               (let [reason (or ex
+                                (str "No transactions provided for norm "
+                                     norm-name))
+                     data {:succeeded acc
+                           :failed {:norm-name norm-name
+                                    :reason reason}}]
+                 (throw (ex-info reason data)))
 
-                :else
-                (-> acc
-                  (reduce-norms conn norm-attr norm-map requires)
-                  (reduce-txes conn norm-attr norm-name txes sync-schema-timeout)))))
-      acc norm-names)))
+               :else
+               (-> acc
+                   (reduce-norms conn norm-attr norm-map requires)
+                   (reduce-txes conn norm-attr norm-name txes sync-schema-timeout)))))
+     acc norm-names)))
 
 (defn ensure-conforms
   "Ensure that norms represented as datoms are conformed-to (installed), be they

--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -249,13 +249,20 @@
                      (db conn))]
         (is (= 1 (count ret)))))))
 
-(deftest get-norm-gets-norms
+(defn txes= [a b]
+  (letfn [(drop-id [xs]
+            (mapv #(dissoc % :db/id)
+                  xs))]
+    (= (map drop-id a)
+       (map drop-id b))))
+
+(deftest test-get-norm-gets-norms
   (testing "get-norm loads :txes key from norms-map"
-    (is (:test1/norm1 sample-norms-map1)
-        (get-norm (fresh-conn) sample-norms-map1 :test1/norm1)))
+    (is (= (:test1/norm1 sample-norms-map1)
+           (get-norm (fresh-conn) sample-norms-map1 :test1/norm1))))
   (testing "get-norm loads :txes-fn key from norms-map"
     (let [conn (fresh-conn)]
-      (is (txes-foo conn)
-          (:txes (get-norm conn sample-norms-map-txes-fns :test-txes-fn/norm1)))
-      (is (txes-bar conn)
-          (:txes (get-norm conn sample-norms-map-txes-fns :test-txes-fn/norm2))))))
+      (is (txes= (txes-foo conn)
+                 (:txes (get-norm conn sample-norms-map-txes-fns :test-txes-fn/norm1))))
+      (is (txes= (txes-bar conn)
+                 (:txes (get-norm conn sample-norms-map-txes-fns :test-txes-fn/norm2)))))))

--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -266,3 +266,11 @@
                  (:txes (get-norm conn sample-norms-map-txes-fns :test-txes-fn/norm1))))
       (is (txes= (txes-bar conn)
                  (:txes (get-norm conn sample-norms-map-txes-fns :test-txes-fn/norm2)))))))
+
+(deftest test-requires-transacted-eagerly
+  (testing "required norms transacted prior to evaluation of requiring `txes-fn` norms"
+    (let [conn  (fresh-conn)
+          norms (read-resource "requiring-sample.edn")]
+      (ensure-conforms conn norms [:requiring/dependent])
+      (let [ret (d/q '[:find ?v :with ?e :where [?e :preferences/color ?v]] (d/db conn))]
+        (is (= [["orange"]] ret))))))

--- a/test/io/rkn/conformity_test.clj
+++ b/test/io/rkn/conformity_test.clj
@@ -215,11 +215,9 @@
 (deftest test-fails-on-bad-norm
   (testing "It explodes when you pass it a bad norm"
     (let [conn (fresh-conn)]
-      (try
-        (ensure-conforms conn sample-norms-map1 [:test2/norm2])
-        (is false "ensure-conforms should have thrown an exception")
-        (catch Exception _
-          (is true "Blew up like it was supposed to."))))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #":db.error/not-an-entity Unable to resolve entity: :db.type/nosuch"
+                            (ensure-conforms conn sample-norms-map2 [:test2/norm2]))))))
 
 (deftest test-loads-norms-from-a-resource
   (testing "loads a datomic schema from edn in a resource"


### PR DESCRIPTION
This PR fixes an issue that may occur when the `:txes-fn` and `:requires` keys are used together.

The bad behavior is a bit subtle because it has some requirements in order to see it occur...

1) Migration B must use `:txes-fn` and must `:require` a previous Migration A.
1) Migration B must reference schema or data applied via Migration A.
1) Migration A must have not yet been transacted into the database -- so either you're rebuilding a new DB or you've built up A and B without calling `ensure-conforms` in between them.
1) You must get unlucky with the non-deterministic sorting of norm names resulting from `(keys norm-map)` such that Migration B is processed before Migration A.

This issue arises because prior to this PR we were evaluating migration fns before recursively walking the `:requires` graph.

The fix proposed here is to eagerly do so before evaluating any txes.

Includes a corresponding new test and some fixes for older tests I happened to notice were mal-formed.