### PR TITLE
Incorrect example for txes-fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For example...
         tx-data  (for [eid foo-eids]
                    {:db/id eid
                     :some/bar :bar-value})]
-    tx-data))
+    [tx-data]))
 ```
 
 


### PR DESCRIPTION
It seems that return value that is returned by function in the example needs to be wrapped with additional vector